### PR TITLE
updating filter_sync_domains function to have reproducibility of results when M not equals to 1

### DIFF
--- a/bim_gw/datasets/utils.py
+++ b/bim_gw/datasets/utils.py
@@ -1,4 +1,5 @@
 import logging
+from math import ceil
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
@@ -99,9 +100,8 @@ def filter_sync_domains(
     domain_mapping = []
     if prop_2_domains < 1:
         labelled_size = int(original_size * prop_2_domains)
-        n_repeats = (len(domains) * original_size) // labelled_size + int(
-            original_size % labelled_size > 0
-        )
+        n_repeats = ceil((len(domains) * len(allowed_indices))
+                              / labelled_size)
 
         domain_items = np.tile(sync_items, n_repeats)
         mapping.extend(domain_items)
@@ -114,9 +114,7 @@ def filter_sync_domains(
         )
         unsync_items = rest[:n_unsync]
         unsync_domain_items = np.concatenate((unsync_items, sync_items))
-        n_repeats = len(allowed_indices) // len(unsync_domain_items) + int(
-            len(allowed_indices) % len(unsync_domain_items) > 0
-        )
+        n_repeats = ceil(len(allowed_indices) / len(unsync_domain_items))
         unsync_domain_items = np.tile(unsync_domain_items, n_repeats)
     mapping.extend(unsync_domain_items)
     domain_mapping.extend([[domains[0]]] * len(unsync_domain_items))

--- a/bim_gw/datasets/utils.py
+++ b/bim_gw/datasets/utils.py
@@ -116,7 +116,7 @@ def filter_sync_domains(
         unsync_domain_items = np.concatenate((unsync_items, sync_items))
         n_repeats = len(allowed_indices) // len(unsync_domain_items) + int(
             len(allowed_indices) % len(unsync_domain_items) > 0
-            )
+        )
         unsync_domain_items = np.tile(unsync_domain_items, n_repeats)
     mapping.extend(unsync_domain_items)
     domain_mapping.extend([[domains[0]]] * len(unsync_domain_items))

--- a/bim_gw/datasets/utils.py
+++ b/bim_gw/datasets/utils.py
@@ -100,8 +100,8 @@ def filter_sync_domains(
     domain_mapping = []
     if prop_2_domains < 1:
         labelled_size = int(original_size * prop_2_domains)
-        n_repeats = ceil((len(domains) * len(allowed_indices))
-                              / labelled_size)
+        n_repeats = ceil((len(domains) * len(allowed_indices)) /
+                         labelled_size)
 
         domain_items = np.tile(sync_items, n_repeats)
         mapping.extend(domain_items)

--- a/bim_gw/datasets/utils.py
+++ b/bim_gw/datasets/utils.py
@@ -114,6 +114,10 @@ def filter_sync_domains(
         )
         unsync_items = rest[:n_unsync]
         unsync_domain_items = np.concatenate((unsync_items, sync_items))
+        n_repeats = len(allowed_indices) // len(unsync_domain_items) + int(
+            len(allowed_indices) % len(unsync_domain_items) > 0
+            )
+        unsync_domain_items = np.tile(unsync_domain_items, n_repeats)
     mapping.extend(unsync_domain_items)
     domain_mapping.extend([[domains[0]]] * len(unsync_domain_items))
     mapping.extend(unsync_domain_items)

--- a/bim_gw/datasets/utils.py
+++ b/bim_gw/datasets/utils.py
@@ -100,9 +100,9 @@ def filter_sync_domains(
     domain_mapping = []
     if prop_2_domains < 1:
         labelled_size = int(original_size * prop_2_domains)
-        n_repeats = ceil((len(domains) * len(allowed_indices)) /
-                         labelled_size)
-
+        n_repeats = ceil(
+            (len(domains) * len(allowed_indices)) / labelled_size
+        )
         domain_items = np.tile(sync_items, n_repeats)
         mapping.extend(domain_items)
         domain_mapping.extend([domains] * len(domain_items))

--- a/tests/datasets/test_simple_shapes_data_module.py
+++ b/tests/datasets/test_simple_shapes_data_module.py
@@ -1,3 +1,4 @@
+import math
 from pathlib import Path
 
 import pytest
@@ -128,7 +129,7 @@ def test_filter_sync_domains_nonzero_prop_available_images_fail():
 
 def test_filter_sync_domains_nonzero_prop_available_images():
     args = get_test_args()
-    args.global_workspace.prop_available_images = 0.5
+    args.global_workspace.prop_available_images = 0.4
     args.global_workspace.prop_labelled_images = 0.1
     allowed_indices = list(range(args.datasets.shapes.n_train_examples))
     mapping, domain_mapping = filter_sync_domains(
@@ -138,18 +139,22 @@ def test_filter_sync_domains_nonzero_prop_available_images():
         args.global_workspace.prop_available_images,
     )
 
-    n_train_examples = len(allowed_indices)
     n_sync_examples = int(
         args.global_workspace.prop_labelled_images * len(allowed_indices)
     )
+    n_available_examples = int(
+        args.global_workspace.prop_available_images * len(allowed_indices)
+    )
+    repeat = math.ceil(len(allowed_indices) / n_available_examples)
+    n_train_examples = n_available_examples * repeat
     expected_counts = {
         "v": n_train_examples,
         "t": n_train_examples,
-        "tv": 2 * n_train_examples,
+        "tv": 2 * len(allowed_indices),
     }
     expected_unique = {
-        "v": n_train_examples,
-        "t": n_train_examples,
+        "v": n_available_examples,
+        "t": n_available_examples,
         "tv": n_sync_examples,
     }
     check_domain_mapping(domain_mapping, expected_counts)

--- a/tests/datasets/test_simple_shapes_data_module.py
+++ b/tests/datasets/test_simple_shapes_data_module.py
@@ -138,9 +138,7 @@ def test_filter_sync_domains_nonzero_prop_available_images():
         args.global_workspace.prop_available_images,
     )
 
-    n_train_examples = int(
-        args.global_workspace.prop_available_images * len(allowed_indices)
-    )
+    n_train_examples = len(allowed_indices)
     n_sync_examples = int(
         args.global_workspace.prop_labelled_images * len(allowed_indices)
     )

--- a/tests/datasets/test_simple_shapes_data_module.py
+++ b/tests/datasets/test_simple_shapes_data_module.py
@@ -128,7 +128,7 @@ def test_filter_sync_domains_nonzero_prop_available_images_fail():
 
 def test_filter_sync_domains_nonzero_prop_available_images():
     args = get_test_args()
-    args.global_workspace.prop_available_images = 0.4
+    args.global_workspace.prop_available_images = 0.5
     args.global_workspace.prop_labelled_images = 0.1
     allowed_indices = list(range(args.datasets.shapes.n_train_examples))
     mapping, domain_mapping = filter_sync_domains(


### PR DESCRIPTION
I think this should work better. But maybe the cases when prop_2_domains = 1 shouldn't have a special condition to preserve dataset size